### PR TITLE
Ticket 8500 - RADIOS AND CHECKBOXES REVERT TO DEFAULT (HTML) STATE WHEN WRAPPED IN IE

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -275,6 +275,7 @@ jQuery.fn.extend({
 	domManip: function( args, table, callback ) {
 		var results, first, fragment, parent,
 			value = args[0],
+			inputs, checked,
 			scripts = [];
 
 		// We can't cloneNode fragments that contain checked, in WebKit
@@ -290,6 +291,11 @@ jQuery.fn.extend({
 				args[0] = value.call(this, i, table ? self.html() : undefined);
 				self.domManip( args, table, callback );
 			});
+		}
+		
+		if ( jQuery.support.noAppendChecked && value ) {
+			inputs = value.jquery ? value.find( "input" ).andSelf().filter( "input" ) : jQuery();
+			checked = inputs && inputs.filter( ":checked" );
 		}
 
 		if ( this[0] ) {
@@ -338,6 +344,10 @@ jQuery.fn.extend({
 			}
 		}
 
+		if ( inputs ) {
+			inputs.filter( ":checked" ).removeAttr( "checked" );
+			checked.attr( "checked", "checked" );
+		}
 		return this;
 	}
 });
@@ -499,7 +509,7 @@ jQuery.each({
 function getAll( elem ) {
 	if ( "getElementsByTagName" in elem ) {
 		return elem.getElementsByTagName( "*" );
-	
+
 	} else if ( "querySelectorAll" in elem ) {
 		return elem.querySelectorAll( "*" );
 

--- a/src/support.js
+++ b/src/support.js
@@ -96,6 +96,15 @@ jQuery.support = (function() {
 	input.checked = true;
 	support.noCloneChecked = input.cloneNode( true ).checked;
 
+	// Bug #8500: Appending Checkbox / Radios can cause "checked" attribute to get reset
+	// IE6 actually sets checked to true on .click(), and if that doesn't work, the
+	// appendChild isn't going to clear the checked state - this should be fairly safe
+	input.checked = false;
+	input.click();
+	// interestingly - if you set input.checked = true it will work - odd eh?
+	// and maybe we should call this "appendResetsChecked"
+	support.noAppendChecked = input.checked && !div.appendChild(input).checked;
+
 	// Make sure that the options inside disabled selects aren't marked as disabled
 	// (WebKit marks them as disabled)
 	select.disabled = true;

--- a/src/support.js
+++ b/src/support.js
@@ -99,11 +99,8 @@ jQuery.support = (function() {
 	// Bug #8500: Appending Checkbox / Radios can cause "checked" attribute to get reset
 	// IE6 actually sets checked to true on .click(), and if that doesn't work, the
 	// appendChild isn't going to clear the checked state - this should be fairly safe
-	input.checked = false;
-	input.click();
-	// interestingly - if you set input.checked = true it will work - odd eh?
-	// and maybe we should call this "appendResetsChecked"
-	support.noAppendChecked = input.checked && !div.appendChild(input).checked;
+	input.checked = true;
+	support.noAppendChecked = !div.appendChild(input).checked;
 
 	// Make sure that the options inside disabled selects aren't marked as disabled
 	// (WebKit marks them as disabled)

--- a/test/unit/manipulation.js
+++ b/test/unit/manipulation.js
@@ -1371,3 +1371,12 @@ test("jQuery.buildFragment - no plain-text caching (Bug #6779)", function() {
     equals($f.text(), bad.join(""), "Cached strings that match Object properties");
 	$f.remove();
 });
+
+test("jQuery.append() - appended inputs don't lose checked state (Bug #8500)", function() {
+	expect(2);
+	var $i = jQuery( "#check1" );
+	ok( $i.is( ":checked"), "Input is checked by default" );
+	$i[ 0 ].checked = false;
+	$i.parent().append($i);
+	ok( !$i.is( ":checked"), "Input is still unchecked after append" );
+});


### PR DESCRIPTION
http://bugs.jquery.com/ticket/8500
